### PR TITLE
Correct copyright to the correct account

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 GlockNessMonster
+Copyright (c) 2015 JSPandz
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
You renamed your account and forgot the LICENSE file.
